### PR TITLE
Correcting some type hints, typos and references

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ furo
 numpydoc
 sphinx_rtd_theme
 sphinx-toolbox
+sphinx_copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.linkcode',
     'sphinx.ext.githubpages',
+    'sphinx_copybutton'
 ]
 
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -78,10 +78,17 @@ The secret is hided in the :py:meth:`~abaqus.Mdb.Mdb.Mdb.saveAs` method:
 .. code-block:: python
 
     def saveAs(self, pathName: str):
-        abaqus = 'abaqus'
-        if 'ABAQUS_BAT_PATH' in os.environ.keys():
-            abaqus = os.environ['ABAQUS_BAT_PATH']
-        os.system('{} cae -noGUI {}'.format(abaqus, os.path.abspath(sys.argv[0])))
+        abaqus = "abaqus"
+        if "ABAQUS_BAT_PATH" in os.environ.keys():
+            abaqus = os.environ["ABAQUS_BAT_PATH"]
+
+        filePath = os.path.abspath(sys.argv[0])
+        fileDir = os.path.dirname(filePath)
+        fileName = os.path.basename(filePath)
+
+        os.system(f"cd {fileDir}")
+        ...
+        os.system(f"{abaqus} cae -noGUI {fileName}")
 
 In this package, the :py:meth:`~abaqus.Mdb.Mdb.Mdb.saveAs` method is reimplemented, if you call this method in your
 script (i.e., `mdb.saveAs('model.cae')`), the Python interpreter (not Abaqus Python interpreter) will use the
@@ -93,11 +100,24 @@ method :py:meth:`~abaqus.Session.Session.Session.openOdb` is also reimplemented:
 
 .. code-block:: python
 
-    def openOdb(self, name: str, *args, **kwargs):
-        abaqus = 'abaqus'
-        if 'ABAQUS_BAT_PATH' in os.environ.keys():
-            abaqus = os.environ['ABAQUS_BAT_PATH']
-        os.system('{} cae database={} script={}'.format(abaqus, os.path.abspath(name), os.path.abspath(sys.argv[0])))
+    def openOdb(self, name: str, *args, **kwargs) -> Odb:
+        self.odbs[name] = odb = Odb(name, *args, **kwargs)
+
+        abaqus = "abaqus"
+        if "ABAQUS_BAT_PATH" in os.environ.keys():
+            abaqus = os.environ["ABAQUS_BAT_PATH"]
+
+        filePath = os.path.abspath(sys.argv[0])
+        fileDir = os.path.dirname(filePath)
+        fileName = os.path.basename(filePath)
+        odbName = os.path.basename(os.path.abspath(name))
+
+        os.system(f"cd {fileDir}")
+        ...
+        os.system(f"{abaqus} cae database={odbName} script={fileName}")
+
+        self.exit()
+        return odb
 
 Therefore, if you want to run your Python script in Abaqus Python environment, please make sure to use these methods.
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -28,7 +28,7 @@ However, if type hints are provided in Python scripting of Abaqus, things will g
 easier, and that is what `pyabaqus` does.
 
 
-The example model described in the following is simple, there is a squre structure, the vertical displacement of the bottom face is fixed, and there is a vertical pressure in the top surface, the Abaqus model is showed as follows:
+The example model described in the following is simple, there is a square structure, the vertical displacement of the bottom face is fixed, and there is a vertical pressure in the top surface, the Abaqus model is showed as follows:
 
 
 .. image:: images/model.png
@@ -77,7 +77,7 @@ First we need to create a sketch that will be used to create the part, we need t
     sketch = model.ConstrainedSketch(name='sketch', sheetSize=1.0)
     sketch.rectangle((0, 0), (1, 1))
 
-In this code, we draw a sketch with a squre. Now we can create a part using this sketch:
+In this code, we draw a sketch with a square. Now we can create a part using this sketch:
 
 .. code-block:: Python
 
@@ -336,7 +336,7 @@ The whole script of this example is showed as follows:
 Extract output data
 -------------------
 
-If we want to extract the output data, we have to write an outout script. 
+If we want to extract the output data, we have to write an output script. 
 
 Header of the output script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -51,7 +51,7 @@ class CellArray:
         """
         pass
 
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True):
+    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> tuple[Cell]:
         """This method returns the object or objects in the CellArray located at the given
         coordinates. findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt
         returns any entity that is at the arbitrary point specified or at a distance of less

--- a/src/abaqus/BasicGeometry/FaceArray.py
+++ b/src/abaqus/BasicGeometry/FaceArray.py
@@ -63,7 +63,7 @@ class FaceArray:
 
     def findAt(
         self, coordinates: tuple, normal: tuple = (), printWarning: Boolean = True
-    ):
+    ) -> tuple[Face]:
         """This method returns the object or objects in the FaceArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any face

--- a/src/abaqus/BoundaryCondition/BoundaryConditionModel.py
+++ b/src/abaqus/BoundaryCondition/BoundaryConditionModel.py
@@ -48,6 +48,7 @@ from .VelocityBaseMotionBCState import VelocityBaseMotionBCState
 from ..Amplitude.CorrelationArray import CorrelationArray
 from ..Model.ModelBase import ModelBase
 from ..Region.Region import Region
+from ..Region.Set import Set
 from ..Region.RegionArray import RegionArray
 
 
@@ -794,7 +795,7 @@ class BoundaryConditionModel(ModelBase):
         self,
         name: str,
         createStepName: str,
-        region: Region,
+        region: typing.Union[Region,Set],
         fieldName: str = "",
         u1: typing.Union[SymbolicConstant, float] = UNSET,
         u2: typing.Union[SymbolicConstant, float] = UNSET,

--- a/src/abaqus/Load/LoadModel.py
+++ b/src/abaqus/Load/LoadModel.py
@@ -1,3 +1,5 @@
+import typing
+
 from abaqusConstants import *
 from .BodyCharge import BodyCharge
 from .BodyConcentrationFlux import BodyConcentrationFlux
@@ -37,7 +39,7 @@ from .SurfaceTraction import SurfaceTraction
 from ..Datum.DatumAxis import DatumAxis
 from ..Model.ModelBase import ModelBase
 from ..Region.Region import Region
-
+from ..Region.Set import Set
 
 class LoadModel(ModelBase):
     """Abaqus creates a Model object named `Model-1` when a session is started.
@@ -1511,7 +1513,7 @@ class LoadModel(ModelBase):
         self,
         name: str,
         createStepName: str,
-        region: Region,
+        region: typing.Union[Region,Set],
         magnitude: float = 0.0,
         hZero: float = 0.0,
         hReference: float = 0.0,

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -899,7 +899,7 @@ class MeshPart(PartBase):
         """
         pass
 
-    def setElementType(self, regions: tuple, elemTypes: tuple[ElemType]):
+    def setElementType(self, regions: tuple, elemTypes: tuple[ElemType,...]):
         """This method assigns element types to the specified regions.
 
         Parameters

--- a/src/abaqus/Section/SectionModel.py
+++ b/src/abaqus/Section/SectionModel.py
@@ -949,7 +949,7 @@ class SectionModel(ModelBase):
         return section
 
     def HomogeneousSolidSection(
-        self, name: str, material: str, thickness: float = 1
+        self, name: str, material: str, thickness: typing.Optional[float] = 1
     ) -> HomogeneousSolidSection:
         """This method creates a HomogeneousSolidSection object.
 

--- a/src/abaqus/Session/SessionBase.py
+++ b/src/abaqus/Session/SessionBase.py
@@ -846,4 +846,4 @@ class SessionBase:
 
     @staticmethod
     def exit():
-        os.system("exit")
+        sys.exit()

--- a/src/abaqus/Sketcher/ConstrainedSketch.py
+++ b/src/abaqus/Sketcher/ConstrainedSketch.py
@@ -480,7 +480,7 @@ class ConstrainedSketch(
         """This method resets the view to be perpendicular to the sketching plane."""
         pass
 
-    def rectangle(self, point1: tuple[float], point2: tuple[float]):
+    def rectangle(self, point1: tuple[float,float], point2: tuple[float,float]):
         """This method creates four lines that form a rectangle with diagonal corners defined by
         the given points and inserts them into the geometry repository of the ConstrainedSketch
         object.

--- a/src/abaqus/XY/XYSession.py
+++ b/src/abaqus/XY/XYSession.py
@@ -545,7 +545,7 @@ class XYSession(XYSessionBase):
         self,
         odb: Odb,
         outputPosition: SymbolicConstant,
-        variable: tuple[tuple[str, SymbolicConstant, tuple[SymbolicConstant, str]]],
+        variable: tuple[tuple[str, SymbolicConstant, tuple[tuple[SymbolicConstant, str],...]],...],
         elementSets: tuple = (),
         elementLabels: tuple = (),
         nodeSets: tuple = (),

--- a/src/abaqus/XY/XYSession.py
+++ b/src/abaqus/XY/XYSession.py
@@ -9,12 +9,7 @@ from .TextStyle import TextStyle
 from .XYData import XYData
 from .XYSessionBase import XYSessionBase
 from ..PathAndProbe.Path import Path
-
-
-# prevent circular imports
-class Odb:
-    pass
-
+from ..Odb.Odb import Odb
 
 class XYSession(XYSessionBase):
     @staticmethod

--- a/src/abaqusConstants.py
+++ b/src/abaqusConstants.py
@@ -2642,8 +2642,8 @@ class BooleanType(int):
         """ x.__xor__(y) <==> x^y """
         pass
 
-
-Boolean = BooleanType
+import typing
+Boolean = typing.Union[BooleanType,int]
 
 
 class SymbolicConstantType(object):

--- a/src/odbAccess.py
+++ b/src/odbAccess.py
@@ -2,7 +2,7 @@ from abaqus.Odb.OdbCommands import *
 from abaqus.Odb.Odb import Odb
 
 
-def openOdb(path: str, *args, **kwargs) -> Odb:
+def openOdb(path: str, readOnly: bool = False, readInternalSets:bool = False) -> Odb:
     abaqus = 'abaqus'
     if 'ABAQUS_BAT_PATH' in os.environ.keys():
         abaqus = os.environ['ABAQUS_BAT_PATH']

--- a/src/odbAccess.py
+++ b/src/odbAccess.py
@@ -2,7 +2,7 @@ from abaqus.Odb.OdbCommands import *
 from abaqus.Odb.Odb import Odb
 
 
-def openOdb(path: str, *args, **kwargs):
+def openOdb(path: str, *args, **kwargs) -> Odb:
     abaqus = 'abaqus'
     if 'ABAQUS_BAT_PATH' in os.environ.keys():
         abaqus = os.environ['ABAQUS_BAT_PATH']

--- a/src/odbAccess.py
+++ b/src/odbAccess.py
@@ -2,7 +2,7 @@ from abaqus.Odb.OdbCommands import *
 from abaqus.Odb.Odb import Odb
 
 
-def openOdb(name: str, *args, **kwargs):
+def openOdb(path: str, *args, **kwargs):
     abaqus = 'abaqus'
     if 'ABAQUS_BAT_PATH' in os.environ.keys():
         abaqus = os.environ['ABAQUS_BAT_PATH']
@@ -10,7 +10,7 @@ def openOdb(name: str, *args, **kwargs):
     filePath = os.path.abspath(sys.argv[0])
     fileDir = os.path.dirname(filePath)
     fileName = os.path.basename(filePath)
-    odbName = os.path.basename(os.path.abspath(name))
+    odbName = os.path.basename(os.path.abspath(path))
 
     os.system(f'cd {fileDir}')
     try:  # If it is a jupyter notebook
@@ -22,4 +22,4 @@ def openOdb(name: str, *args, **kwargs):
         pass
     os.system(f'{abaqus} cae database={odbName} script={fileName}')
     os.system('exit')
-    return Odb(name)
+    return Odb(path)


### PR DESCRIPTION
Mostly following the pyabaqus tutorial and some Abaqus Scripting reference examples, Pylance type checker raised some warnings that lead to these corrections. Be free to aprove or reprove.
